### PR TITLE
Memo optimizations

### DIFF
--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -3,6 +3,7 @@ var async = require('async');
 var mpath = require('mpath');
 var debug = require('debug')('lounge');
 
+var MemoDriver = require('./memodriver');
 var Document = require('./document');
 var utils = require('./utils');
 
@@ -649,7 +650,7 @@ CouchbaseDocument.prototype.$_removeRefField = function (doc, path, thing, optio
 
   if (model && thing) {
     if (utils.isString(thing)) {
-      model.$_findById(thing, {}, false, function (err, doc) {
+      model.$_findById(thing, {}, null, function (err, doc) {
         if (err) {
           return fn(err);
         }
@@ -811,10 +812,16 @@ function hasPopulate(options) {
  * @param fn
  * @returns {*}
  */
-CouchbaseDocument.prototype.$_populate = function (options, fn) {
+CouchbaseDocument.prototype.$_populate = function (options, memo, fn) {
   if (typeof options === 'function') {
     fn = options;
+    memo = null;
     options = {};
+  }
+
+  if (typeof memo === 'function' && !fn) {
+    fn = memo;
+    memo = null;
   }
 
   if (!fn) {
@@ -855,7 +862,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
         return eachCB();
       }
 
-      Model.$_findById(id, options, true, function (err, results, missed) {
+      Model.$_findById(id, options, memo, function (err, results, missed) {
         if (err) {
           return eachCB(err);
         }
@@ -922,7 +929,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
     opts.populate = rest;
 
     // get the ref doc and populate the rest recursively
-    Model.$_findById(id, opts, true, function (err, results, missed) {
+    Model.$_findById(id, opts, memo, function (err, results, missed) {
       if (err) {
         return fn(err);
       }
@@ -941,7 +948,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
     async.eachLimit(options.populate, 10, function (part, eaCb) {
       var opts = utils.cloneDeep(options);
       opts.populate = part;
-      return self.$_populate(opts, eaCb);
+      return self.$_populate(opts, memo, eaCb);
     }, function (err) {
       return fn(err, self, missing);
     });
@@ -956,8 +963,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
  * @param {Function} fn callback
  */
 CouchbaseDocument.findById = function (id, options, fn) {
-  var self = this;
-  this.db.getm.clear();
+  var memo = new MemoDriver(this.db);
 
   if (typeof options === 'function') {
     fn = options;
@@ -989,20 +995,26 @@ CouchbaseDocument.findById = function (id, options, fn) {
   var modelName = this.prototype.modelName;
   debug(modelName + '.findById. id: ' + id);
 
-  this.$_findById(id, options, true, fn);
-  self.db.getm.clear();
+  this.$_findById(id, options, memo, fn);
+  memo.clear();
 };
 
 CouchbaseDocument.$_findById = function (id, options, memo, fn) {
   var self = this;
-  var getFn = memo ? 'getm' : 'get';
+
+  if (typeof memo === 'function' && !fn) {
+    fn = memo;
+    memo = null;
+  }
+
+  var driver = memo ? memo : this.db;
 
   if (Array.isArray(id)) {
     var fullIds = _.map(id, function (curId) {
       return self.getDocumentKeyValue(curId, true);
     });
 
-    self.db[getFn](fullIds, function (err, results, misses) {
+    driver.get(fullIds, function (err, results, misses) {
       if (err) {
         return fn(err, results, misses);
       }
@@ -1013,7 +1025,7 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
 
       var modelObjs = _.map(results, self.$_createModelObject, self);
       async.eachLimit(modelObjs, 10, function (modelObj, eachCB) {
-        modelObj.$_populate(options, function (err, popObj, missed) {
+        modelObj.$_populate(options, memo, function (err, popObj, missed) {
           if (missed && missed.length > 0) {
             utils.concatArrays(misses, missed);
           }
@@ -1026,7 +1038,7 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
   }
   else {
     id = this.getDocumentKeyValue(id, true);
-    self.db[getFn](id, function (err, getRes) {
+    driver.get(id, function (err, getRes) {
       if (err) {
         return fn(err);
       }
@@ -1036,7 +1048,7 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
         return fn(new Error('no document for id: ' + id));
       }
 
-      modelObj.$_populate(options, fn);
+      modelObj.$_populate(options, memo, fn);
     });
   }
 };
@@ -1051,7 +1063,7 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
 CouchbaseDocument.$_findByIndexValue = function (param, indexPath, options, fn) {
   var self = this;
 
-  self.db.getm.clear();
+  var memodriver = new MemoDriver(this.db);
 
   if (typeof options === 'function') {
     fn = options;
@@ -1069,7 +1081,7 @@ CouchbaseDocument.$_findByIndexValue = function (param, indexPath, options, fn) 
   var modelName = this.prototype.modelName;
   debug(modelName + '.findByIndexValue. value: ' + param + ' path: ' + indexPath);
 
-  this.db.getm(param, function (err, res) {
+  memodriver.get(param, function (err, res) {
     if (err) {
       return fn(err);
     }
@@ -1079,7 +1091,7 @@ CouchbaseDocument.$_findByIndexValue = function (param, indexPath, options, fn) 
     }
 
     var docKey = self.schema.getDocumentKeyValue(res.value.key, true);
-    self.db.getm(docKey, function (err, getRes) {
+    memodriver.get(docKey, function (err, getRes) {
       if (err) {
         return fn(err);
       }
@@ -1093,8 +1105,8 @@ CouchbaseDocument.$_findByIndexValue = function (param, indexPath, options, fn) 
         return fn(new Error('no document for id: ' + id));
       }
 
-      mo.$_populate(options, fn);
-      self.db.getm.clear();
+      mo.$_populate(options, memodriver, fn);
+      memodriver.clear();
     });
   });
 };

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -948,6 +948,13 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
   }
 };
 
+/**
+ * Find a document by key value.
+ * @param {String} id the document id / key
+ * @param {Object} options
+ * - `populate` - populate options, can be a `Boolean`, `String` representing a path, or an `Array` of `String` paths
+ * @param {Function} fn callback
+ */
 CouchbaseDocument.findById = function (id, options, fn) {
   var self = this;
   this.db.getm.clear();
@@ -988,14 +995,6 @@ CouchbaseDocument.findById = function (id, options, fn) {
   });
 };
 
-/**
- * Find a document by key value.
- * @param {String} id the document id / key
- * @param {Object} options
- * - `populate` - populate options, can be a `Boolean`, `String` representing a path, or an `Array` of `String` paths
- * @param memo - whether to use get memoization
- * @param {Function} fn callback
- */
 CouchbaseDocument.$_findById = function (id, options, memo, fn) {
   var self = this;
   var getFn = memo ? 'getm' : 'get';

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -865,7 +865,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
         }
 
         if (missed && missed.length > 0) {
-          missing = missing.concat(missed);
+          Array.prototype.push.apply(missing, missed);
         }
         return eachCB()
       });
@@ -931,7 +931,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
       }
 
       if (missed && missed.length > 0) {
-        missing = missing.concat(missed);
+        Array.prototype.push.apply(missing, missed);
       }
 
       return fn(err, self, missing);
@@ -1000,7 +1000,6 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
   var self = this;
   var getFn = memo ? 'getm' : 'get';
 
-
   if (Array.isArray(id)) {
     var fullIds = _.map(id, function (curId) {
       return self.getDocumentKeyValue(curId, true);
@@ -1018,7 +1017,9 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
       var modelObjs = _.map(results, self.$_createModelObject, self);
       async.eachLimit(modelObjs, 10, function (modelObj, eachCB) {
         modelObj.$_populate(options, function (err, popObj, missed) {
-          misses = misses.concat(missed);
+          if(missed && missed.length > 0) {
+            Array.prototype.push.apply(misses, missed);
+          }
           return eachCB(err);
         });
       }, function (err) {

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -1087,15 +1087,7 @@ CouchbaseDocument.$_findByIndexValue = function (param, indexPath, options, fn) 
         return fn();
       }
 
-      var mo;
-
-      if (self.schema.hasRefPath(indexPath)) {
-        var Model = self.$_getRefModel(indexPath);
-        mo = Model.$_createModelObject(getRes);
-      }
-      else {
-        mo = self.$_createModelObject(getRes);
-      }
+      var mo = self.$_createModelObject(getRes);
 
       if (!mo) {
         return fn(new Error('no document for id: ' + id));

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -176,7 +176,7 @@ CouchbaseDocument.prototype.save = function (data, options, fn) {
   }
 
   if (!fn) {
-    fn = utils.noop;
+    fn = _.noop;
   }
 
   if (!options) {
@@ -576,7 +576,7 @@ CouchbaseDocument.prototype.remove = function (options, fn) {
   }
 
   if (!fn) {
-    fn = utils.noop;
+    fn = _.noop;
   }
 
   if (!options) {
@@ -969,7 +969,7 @@ CouchbaseDocument.findById = function (id, options, fn) {
   }
 
   if (!fn) {
-    fn = utils.noop;
+    fn = _.noop;
   }
 
   if (this.config.alwaysReturnArrays && !Array.isArray(id)) {
@@ -989,10 +989,8 @@ CouchbaseDocument.findById = function (id, options, fn) {
   var modelName = this.prototype.modelName;
   debug(modelName + '.findById. id: ' + id);
 
-  this.$_findById(id, options, true, function (err, res, miss) {
-    self.db.getm.clear();
-    return fn(err, res, miss);
-  });
+  this.$_findById(id, options, true, fn);
+  self.db.getm.clear();
 };
 
 CouchbaseDocument.$_findById = function (id, options, memo, fn) {
@@ -1016,7 +1014,7 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
       var modelObjs = _.map(results, self.$_createModelObject, self);
       async.eachLimit(modelObjs, 10, function (modelObj, eachCB) {
         modelObj.$_populate(options, function (err, popObj, missed) {
-          if(missed && missed.length > 0) {
+          if (missed && missed.length > 0) {
             Array.prototype.push.apply(misses, missed);
           }
           return eachCB(err);
@@ -1047,19 +1045,31 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
  * Find by index document value. generic implementation that we hook up into Models.
  * @param param
  * @param indexPath
+ * @param options
  * @param fn
  */
-CouchbaseDocument.$_findByIndexValue = function (param, indexPath, fn) {
+CouchbaseDocument.$_findByIndexValue = function (param, indexPath, options, fn) {
   var self = this;
 
-  if (!fn || typeof fn !== 'function') {
+  self.db.getm.clear();
+
+  if (typeof options === 'function') {
+    fn = options;
+    options = {};
+  }
+
+  if (!options) {
+    options = {};
+  }
+
+  if (!fn) {
     fn = _.noop;
   }
 
   var modelName = this.prototype.modelName;
   debug(modelName + '.findByIndexValue. value: ' + param + ' path: ' + indexPath);
 
-  this.db.get(param, function (err, res) {
+  this.db.getm(param, function (err, res) {
     if (err) {
       return fn(err);
     }
@@ -1069,7 +1079,7 @@ CouchbaseDocument.$_findByIndexValue = function (param, indexPath, fn) {
     }
 
     var docKey = self.schema.getDocumentKeyValue(res.value.key, true);
-    self.db.get(docKey, function (err, getRes) {
+    self.db.getm(docKey, function (err, getRes) {
       if (err) {
         return fn(err);
       }
@@ -1077,12 +1087,22 @@ CouchbaseDocument.$_findByIndexValue = function (param, indexPath, fn) {
         return fn();
       }
 
+      var mo;
+
       if (self.schema.hasRefPath(indexPath)) {
         var Model = self.$_getRefModel(indexPath);
-        return Model.$_createModelObject(getRes);
+        mo = Model.$_createModelObject(getRes);
+      }
+      else {
+        mo = self.$_createModelObject(getRes);
       }
 
-      return fn(null, self.$_createModelObject(getRes));
+      if (!mo) {
+        return fn(new Error('no document for id: ' + id));
+      }
+
+      mo.$_populate(options, fn);
+      self.db.getm.clear();
     });
   });
 };

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -780,7 +780,7 @@ CouchbaseDocument.$_createModelObject = function (getRes) {
  * @param options
  * @returns {*}
  */
-CouchbaseDocument.prototype.$_hasPopulate = function (options) {
+function hasPopulate(options) {
   if (!options) {
     return false;
   }
@@ -803,7 +803,7 @@ CouchbaseDocument.prototype.$_hasPopulate = function (options) {
   }
 
   return false;
-};
+}
 
 /*!
  * Populates embedded documents into this instance based on populate options
@@ -814,7 +814,7 @@ CouchbaseDocument.prototype.$_hasPopulate = function (options) {
 CouchbaseDocument.prototype.$_populate = function (options, fn) {
   var self = this;
 
-  if (!this.$_hasPopulate(options)) {
+  if (hasPopulate(options)) {
     return process.nextTick(function () {
       return fn(null, self, []);
     });
@@ -862,7 +862,8 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
     var parts = options.populate.split('.');
     var part = parts[0];
 
-    if (/^\d+$/.test(part) || !self.schema.hasRefPath(part)) {
+    // first part must be a ref path and canont be a digit
+    if (!self.schema.hasRefPath(part) || /^\d+$/.test(part)) {
       return process.nextTick(function () {
         return fn(null, self, []);
       });
@@ -871,15 +872,20 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
     var path = part;
     var nextPart = parts[1];
     var restIndex = 1;
+
+    // if next part is an array index append it to path and adjust
     if (nextPart && /^\d+$/.test(nextPart)) {
       path = part.concat('.', nextPart);
       restIndex = 2;
     }
+
+    // create the rest of path
     var rest;
     if (parts.length > restIndex) {
       rest = parts.slice(restIndex).join('.');
     }
 
+    // get model
     var Model = self.$_getRefModel(part);
     if (!Model) {
       console.warn('No model for path: %s', part);
@@ -888,17 +894,19 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
       });
     }
 
+    // get the ref key
     var id = mpath.get(path, self, '$_table');
-
     if (!id || id instanceof Model) {
       return process.nextTick(function () {
         return fn(null, self, []);
       });
     }
 
+    // adjust the populate option for the rest
     var opts = utils.cloneDeep(options);
     opts.populate = rest;
 
+    // get the ref doc and populate the rest recursively
     Model.findById(id, opts, function (err, results, missed) {
       if (err) {
         return fn(err);
@@ -968,7 +976,7 @@ CouchbaseDocument.findById = function (id, options, fn) {
       return self.getDocumentKeyValue(curId, true);
     });
 
-    self.db.get(fullIds, function (err, results, misses) {
+    self.db.getm(fullIds, function (err, results, misses) {
       if (err) {
         return fn(err, results, misses);
       }
@@ -990,7 +998,7 @@ CouchbaseDocument.findById = function (id, options, fn) {
   }
   else {
     id = this.getDocumentKeyValue(id, true);
-    self.db.get(id, function (err, getRes) {
+    self.db.getm(id, function (err, getRes) {
       if (err) {
         return fn(err);
       }

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -649,7 +649,7 @@ CouchbaseDocument.prototype.$_removeRefField = function (doc, path, thing, optio
 
   if (model && thing) {
     if (utils.isString(thing)) {
-      model.findById(thing, function (err, doc) {
+      model.$_findById(thing, {}, false, function (err, doc) {
         if (err) {
           return fn(err);
         }
@@ -812,9 +812,22 @@ function hasPopulate(options) {
  * @returns {*}
  */
 CouchbaseDocument.prototype.$_populate = function (options, fn) {
+  if (typeof options === 'function') {
+    fn = options;
+    options = {};
+  }
+
+  if (!fn) {
+    fn = _.noop;
+  }
+
+  if (!options) {
+    options = {};
+  }
+
   var self = this;
 
-  if (hasPopulate(options)) {
+  if (!hasPopulate(options)) {
     return process.nextTick(function () {
       return fn(null, self, []);
     });
@@ -842,7 +855,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
         return eachCB();
       }
 
-      Model.findById(id, options, function (err, results, missed) {
+      Model.$_findById(id, options, true, function (err, results, missed) {
         if (err) {
           return eachCB(err);
         }
@@ -851,7 +864,9 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
           mpath.set(path, results, self, '$_table');
         }
 
-        missing = missing.concat(missed);
+        if (missed && missed.length > 0) {
+          missing = missing.concat(missed);
+        }
         return eachCB()
       });
     }, function eaFn(err) {
@@ -907,7 +922,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
     opts.populate = rest;
 
     // get the ref doc and populate the rest recursively
-    Model.findById(id, opts, function (err, results, missed) {
+    Model.$_findById(id, opts, true, function (err, results, missed) {
       if (err) {
         return fn(err);
       }
@@ -915,7 +930,9 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
         mpath.set(path, results, self, '$_table');
       }
 
-      missing = missing.concat(missed);
+      if (missed && missed.length > 0) {
+        missing = missing.concat(missed);
+      }
 
       return fn(err, self, missing);
     });
@@ -931,15 +948,9 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
   }
 };
 
-/**
- * Find a document by key value.
- * @param {String} id the document id / key
- * @param {Object} options
- * - `populate` - populate options, can be a `Boolean`, `String` representing a path, or an `Array` of `String` paths
- * @param {Function} fn callback
- */
 CouchbaseDocument.findById = function (id, options, fn) {
   var self = this;
+  this.db.getm.clear();
 
   if (typeof options === 'function') {
     fn = options;
@@ -971,12 +982,31 @@ CouchbaseDocument.findById = function (id, options, fn) {
   var modelName = this.prototype.modelName;
   debug(modelName + '.findById. id: ' + id);
 
+  this.$_findById(id, options, true, function (err, res, miss) {
+    self.db.getm.clear();
+    return fn(err, res, miss);
+  });
+};
+
+/**
+ * Find a document by key value.
+ * @param {String} id the document id / key
+ * @param {Object} options
+ * - `populate` - populate options, can be a `Boolean`, `String` representing a path, or an `Array` of `String` paths
+ * @param memo - whether to use get memoization
+ * @param {Function} fn callback
+ */
+CouchbaseDocument.$_findById = function (id, options, memo, fn) {
+  var self = this;
+  var getFn = memo ? 'getm' : 'get';
+
+
   if (Array.isArray(id)) {
     var fullIds = _.map(id, function (curId) {
       return self.getDocumentKeyValue(curId, true);
     });
 
-    self.db.getm(fullIds, function (err, results, misses) {
+    self.db[getFn](fullIds, function (err, results, misses) {
       if (err) {
         return fn(err, results, misses);
       }
@@ -998,7 +1028,7 @@ CouchbaseDocument.findById = function (id, options, fn) {
   }
   else {
     id = this.getDocumentKeyValue(id, true);
-    self.db.getm(id, function (err, getRes) {
+    self.db[getFn](id, function (err, getRes) {
       if (err) {
         return fn(err);
       }

--- a/lib/couchdoc.js
+++ b/lib/couchdoc.js
@@ -865,7 +865,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
         }
 
         if (missed && missed.length > 0) {
-          Array.prototype.push.apply(missing, missed);
+          utils.concatArrays(missing, missed);
         }
         return eachCB()
       });
@@ -931,7 +931,7 @@ CouchbaseDocument.prototype.$_populate = function (options, fn) {
       }
 
       if (missed && missed.length > 0) {
-        Array.prototype.push.apply(missing, missed);
+        utils.concatArrays(missing, missed);
       }
 
       return fn(err, self, missing);
@@ -1015,7 +1015,7 @@ CouchbaseDocument.$_findById = function (id, options, memo, fn) {
       async.eachLimit(modelObjs, 10, function (modelObj, eachCB) {
         modelObj.$_populate(options, function (err, popObj, missed) {
           if (missed && missed.length > 0) {
-            Array.prototype.push.apply(misses, missed);
+            utils.concatArrays(misses, missed);
           }
           return eachCB(err);
         });

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -13,8 +13,9 @@ var memoize = require('memoizee');
  */
 function Driver(bucket) {
   this.bucket = bucket;
-  this.getm = memoize(this.get.bind(this), {async: true, length: 2});
+  this.getm = memoize(this.get.bind(this), {async: true, length: 1, maxAge: 5000});
 }
+
 
 /**
  * A simplified get for our use. Properly handles key not found errors. In case of multi call, returns array of found
@@ -71,7 +72,7 @@ Driver.prototype.get = function (keys, options, fn) {
     });
   }
   else {
-    debug('driver.get. keys: ' + keys);
+    debug('driver.get. keys: ' + keys + ' options: ' + JSON.stringify(options));
     this.bucket.get(keys, options, function (err, getRes) {
       if (err && utils.isKeyNotFound(err)) {
         err = null;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2,7 +2,6 @@ var couchbase = require('couchbase');
 var _ = require('lodash');
 var debug = require('debug')('lounge');
 var utils = require('./utils');
-var memoize = require('memoizee');
 
 /**
  * Couchbase driver util class. Just wraps couchbase Bucket and overrides some functions.
@@ -13,7 +12,6 @@ var memoize = require('memoizee');
  */
 function Driver(bucket) {
   this.bucket = bucket;
-  this.getm = memoize(this.get.bind(this), {async: true, length: 1, maxAge: 5000});
 }
 
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -72,7 +72,7 @@ Driver.prototype.get = function (keys, options, fn) {
     });
   }
   else {
-    debug('driver.get. keys: ' + keys + ' options: ' + JSON.stringify(options));
+    debug('driver.get. keys: ' + keys);
     this.bucket.get(keys, options, function (err, getRes) {
       if (err && utils.isKeyNotFound(err)) {
         err = null;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -2,6 +2,7 @@ var couchbase = require('couchbase');
 var _ = require('lodash');
 var debug = require('debug')('lounge');
 var utils = require('./utils');
+var memoize = require('memoizee');
 
 /**
  * Couchbase driver util class. Just wraps couchbase Bucket and overrides some functions.
@@ -12,6 +13,7 @@ var utils = require('./utils');
  */
 function Driver(bucket) {
   this.bucket = bucket;
+  this.getm = memoize(this.get.bind(this), {async: true, length: 2});
 }
 
 /**
@@ -112,6 +114,7 @@ Driver.prototype.remove = function (key, options, fn) {
     return fn(err, rres);
   });
 };
+
 
 /**
  * Wrap the Couchbase bucket and return a new Driver instance.

--- a/lib/memodriver.js
+++ b/lib/memodriver.js
@@ -1,0 +1,24 @@
+var memoize = require('memoizee');
+
+module.exports = MemoDriver;
+
+/**
+ * Finder utility class. Wraps driver and adds memoization to get
+ * @param driver
+ * @constructor
+ */
+function MemoDriver(driver) {
+  this.driver = driver;
+
+  /**
+   * Same as driver.get but memoizes the result for 5 s
+   */
+  this.get = memoize(this.driver.get.bind(this.driver), {async: true, length: 1, maxAge: 5000});
+
+  /**
+   * Clears the memo cache
+   */
+  this.clear = function() {
+    this.get.clear();
+  }
+}

--- a/lib/model.js
+++ b/lib/model.js
@@ -153,13 +153,13 @@ function setupIndexFunctions(InstanceModel) {
         var name = indexes[v].name;
         var fnName = 'findBy'.concat(inflection.camelize(name));
 
-        InstanceModel[fnName] = function (param, fn) {
+        InstanceModel[fnName] = function (param, options, fn) {
           if (!param) {
             return process.nextTick(fn);
           }
 
           var docKey = this.schema.getRefKey(name, param);
-          return InstanceModel.$_findByIndexValue(docKey, path, fn);
+          return InstanceModel.$_findByIndexValue(docKey, path, options, fn);
         };
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -224,3 +224,6 @@ exports.endsWith = function (subjectString, searchString, position) {
   return lastIndex !== -1 && lastIndex === position;
 };
 
+exports.concatArrays = function (a1, a2) {
+  Array.prototype.push.apply(a1, a2);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lounge",
   "description": "Simple Mongoose-inspired ODM for Couchbase",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/bojand/lounge",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "hooks-fixed": "^1.1.0",
     "inflection": "^1.8.0",
     "lodash": "^3.10.1",
+    "memoizee":"~0.3.9",
     "mpath": "^0.2.1",
     "sliced": "^1.0.1",
     "traverse": "^0.6.6",

--- a/test/helpers/pop_setup2.js
+++ b/test/helpers/pop_setup2.js
@@ -1,0 +1,70 @@
+var lounge = require('../../lib');
+var _ = require('lodash');
+
+var data = {
+  users: [{
+    "firstName": "Bobby",
+    "lastName": "Jordan",
+    "email": "bjordan0@apple.com",
+    "company": "f32a5f17-b827-41b8-83fc-637976a393a5"
+  }, {
+    "firstName": "Rachel",
+    "lastName": "Porter",
+    "email": "rporter1@ning.com",
+    "company": "company::9be225c9-79a8-4ec4-9113-689a800f825c"
+  }, {
+    "firstName": "Judith",
+    "lastName": "Oliver",
+    "email": "joliver2@imgur.com",
+    "company": "company::52a1a9b1-5669-4133-9575-2786ebc69635"
+  }, {
+    "firstName": "Kathleen",
+    "lastName": "Hernandez",
+    "email": "khernandez3@who.int"
+  }],
+  companies: [{
+    "id": "f32a5f17-b827-41b8-83fc-637976a393a5",
+    "name": "Jaxspan",
+    "streetAddress": "11 Briar Crest Drive",
+    "city": "Columbus",
+    "country": "United States",
+    "postalCode": "43220",
+    "state": "Ohio"
+  }, {
+    "id": "9be225c9-79a8-4ec4-9113-689a800f825c",
+    "name": "Thoughtstorm",
+    "streetAddress": "92862 Autumn Leaf Crossing",
+    "city": "Daytona Beach",
+    "country": "United States",
+    "postalCode": "32128",
+    "state": "Florida"
+  }, {
+    "id": "52a1a9b1-5669-4133-9575-2786ebc69635",
+    "name": "Blogpad",
+    "streetAddress": "3 Vera Pass",
+    "city": "Huntsville",
+    "country": "United States",
+    "postalCode": "77343",
+    "state": "Texas"
+  }, {
+    "id": "343d8f1a-29de-459d-9294-2e44c35f266e",
+    "name": "Bubbletube",
+    "streetAddress": "84942 Mendota Hill",
+    "city": "Hampton",
+    "country": "United States",
+    "postalCode": "23668",
+    "state": "Virginia"
+  }, {
+    "id": "1fabd1fe-72eb-421a-9007-19bfd69f2eb7",
+    "name": "Avavee",
+    "streetAddress": "334 Knutson Place",
+    "city": "Saint Paul",
+    "country": "United States",
+    "postalCode": "55115",
+    "state": "Minnesota"
+  }]
+};
+
+exports.getData = function () {
+  return _.cloneDeep(data);
+};

--- a/test/index.query.spec.js
+++ b/test/index.query.spec.js
@@ -9,7 +9,7 @@ var Schema = lounge.Schema;
 
 var bucket;
 
-describe.only('Model index query tests', function () {
+describe('Model index query tests', function () {
 
   describe('index query tests without populate', function () {
     beforeEach(function (done) {

--- a/test/index.query.spec.js
+++ b/test/index.query.spec.js
@@ -177,7 +177,7 @@ describe('Model index query tests', function () {
         lounge.connect({
           bucket: bucket
         }, function () {
-          bucket.manager().flush(function(err) {
+          bucket.manager().flush(function (err) {
             if (err) {
               return done(err);
             }

--- a/test/index.query.spec.js
+++ b/test/index.query.spec.js
@@ -1,5 +1,6 @@
 var couchbase = require('couchbase');
 var _ = require('lodash');
+var async = require('async');
 var testUtil = require('./helpers/utils');
 var expect = require('chai').expect;
 
@@ -8,137 +9,127 @@ var Schema = lounge.Schema;
 
 var bucket;
 
-describe('Model index query tests', function () {
-  beforeEach(function (done) {
-    if (lounge) {
-      lounge.disconnect();
-    }
+describe.only('Model index query tests', function () {
 
-    lounge = new lounge.Lounge(); // recreate it
+  describe('index query tests without populate', function () {
+    beforeEach(function (done) {
+      if (lounge) {
+        lounge.disconnect();
+      }
 
-    var cluster = testUtil.getCluser();
-    bucket = cluster.openBucket('lounge_test', function (err) {
-      lounge.connect({
-        bucket: bucket
-      }, function () {
-        bucket.manager().flush(done);
+      lounge = new lounge.Lounge(); // recreate it
+
+      var cluster = testUtil.getCluser();
+      bucket = cluster.openBucket('lounge_test', function (err) {
+        lounge.connect({
+          bucket: bucket
+        }, function () {
+          bucket.manager().flush(done);
+        });
       });
     });
-  });
 
-  it('should query using simple reference document', function (done) {
-    var userSchema = lounge.schema({
-      firstName: String,
-      lastName: String,
-      email: {type: String, index: true}
-    });
+    it('should query using simple reference document', function (done) {
+      var userSchema = lounge.schema({
+        firstName: String,
+        lastName: String,
+        email: {type: String, index: true}
+      });
 
-    var User = lounge.model('User', userSchema);
+      var User = lounge.model('User', userSchema);
 
-    var userData = {
-      firstName: 'Joe',
-      lastName: 'Smith',
-      email: 'joe@gmail.com'
-    };
+      var userData = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'joe@gmail.com'
+      };
 
-    var user = new User(userData);
+      var user = new User(userData);
 
-    user.save(function (err, savedDoc) {
-      expect(err).to.not.be.ok;
-      expect(savedDoc).to.be.ok;
-
-
-      User.findByEmail(user.email, function (err, rdoc) {
+      user.save(function (err, savedDoc) {
         expect(err).to.not.be.ok;
+        expect(savedDoc).to.be.ok;
 
-        expect(rdoc).to.be.ok;
-        expect(rdoc).to.be.an('object');
-        expect(rdoc).to.be.an.instanceof(User);
-        expect(rdoc.id).to.be.ok;
-        expect(rdoc.id).to.be.a('string');
 
-        expect(rdoc.id).to.equal(user.id);
-        expect(rdoc.firstName).to.equal(userData.firstName);
-        expect(rdoc.lastName).to.equal(userData.lastName);
-        expect(rdoc.email).to.equal(userData.email);
+        User.findByEmail(user.email, function (err, rdoc) {
+          expect(err).to.not.be.ok;
 
-        done();
+          expect(rdoc).to.be.ok;
+          expect(rdoc).to.be.an('object');
+          expect(rdoc).to.be.an.instanceof(User);
+          expect(rdoc.id).to.be.ok;
+          expect(rdoc.id).to.be.a('string');
+
+          expect(rdoc.id).to.equal(user.id);
+          expect(rdoc.firstName).to.equal(userData.firstName);
+          expect(rdoc.lastName).to.equal(userData.lastName);
+          expect(rdoc.email).to.equal(userData.email);
+
+          done();
+        });
       });
     });
-  });
 
-  it('should query using simple reference document respecting key options', function (done) {
-    var userSchema = lounge.schema({
-      firstName: String,
-      lastName: String,
-      email: {type: String, index: true},
-      username: {type: String, key: true, generate: false}
-    });
+    it('should query using simple reference document respecting key options', function (done) {
+      var userSchema = lounge.schema({
+        firstName: String,
+        lastName: String,
+        email: {type: String, index: true},
+        username: {type: String, key: true, generate: false}
+      });
 
-    var User = lounge.model('User', userSchema);
+      var User = lounge.model('User', userSchema);
 
-    var userData = {
-      firstName: 'Joe',
-      lastName: 'Smith',
-      email: 'joe@gmail.com',
-      username: 'jsmith'
-    };
+      var userData = {
+        firstName: 'Joe',
+        lastName: 'Smith',
+        email: 'joe@gmail.com',
+        username: 'jsmith'
+      };
 
-    var user = new User(userData);
+      var user = new User(userData);
 
-    user.save(function (err, savedDoc) {
-      expect(err).to.not.be.ok;
-      expect(savedDoc).to.be.ok;
-
-      User.findByEmail(user.email, function (err, rdoc) {
+      user.save(function (err, savedDoc) {
         expect(err).to.not.be.ok;
+        expect(savedDoc).to.be.ok;
 
-        expect(rdoc).to.be.ok;
-        expect(rdoc).to.be.an('object');
-        expect(rdoc).to.be.an.instanceof(User);
+        User.findByEmail(user.email, function (err, rdoc) {
+          expect(err).to.not.be.ok;
 
-        expect(rdoc.username).to.equal(user.username);
-        expect(rdoc.firstName).to.equal(userData.firstName);
-        expect(rdoc.lastName).to.equal(userData.lastName);
-        expect(rdoc.email).to.equal(userData.email);
+          expect(rdoc).to.be.ok;
+          expect(rdoc).to.be.an('object');
+          expect(rdoc).to.be.an.instanceof(User);
 
-        done();
+          expect(rdoc.username).to.equal(user.username);
+          expect(rdoc.firstName).to.equal(userData.firstName);
+          expect(rdoc.lastName).to.equal(userData.lastName);
+          expect(rdoc.email).to.equal(userData.email);
+
+          done();
+        });
       });
     });
-  });
 
-  it('should query index values for array', function (done) {
-    var userSchema = new lounge.Schema({
-      firstName: String,
-      lastName: String,
-      usernames: [{type: String, index: true, indexName: 'username'}]
-    });
+    it('should query index values for array', function (done) {
+      var userSchema = new lounge.Schema({
+        firstName: String,
+        lastName: String,
+        usernames: [{type: String, index: true, indexName: 'username'}]
+      });
 
-    var User = lounge.model('User', userSchema);
+      var User = lounge.model('User', userSchema);
 
-    var user = new User({
-      firstName: 'Joe',
-      lastName: 'Smith',
-      usernames: ['user1', 'user2']
-    });
+      var user = new User({
+        firstName: 'Joe',
+        lastName: 'Smith',
+        usernames: ['user1', 'user2']
+      });
 
-    user.save(function (err, savedDoc) {
-      expect(err).to.not.be.ok;
-      expect(savedDoc).to.be.ok;
-
-      User.findByUsername(user.usernames[0], function (err, rdoc) {
+      user.save(function (err, savedDoc) {
         expect(err).to.not.be.ok;
+        expect(savedDoc).to.be.ok;
 
-        expect(rdoc).to.be.ok;
-        expect(rdoc).to.be.an('object');
-        expect(rdoc).to.be.an.instanceof(User);
-
-        expect(rdoc.usernames.sort()).to.deep.equal(user.usernames.sort());
-        expect(rdoc.firstName).to.equal(user.firstName);
-        expect(rdoc.lastName).to.equal(user.lastName);
-        expect(rdoc.email).to.equal(user.email);
-
-        User.findByUsername(user.usernames[1], function (err, rdoc) {
+        User.findByUsername(user.usernames[0], function (err, rdoc) {
           expect(err).to.not.be.ok;
 
           expect(rdoc).to.be.ok;
@@ -150,8 +141,166 @@ describe('Model index query tests', function () {
           expect(rdoc.lastName).to.equal(user.lastName);
           expect(rdoc.email).to.equal(user.email);
 
-          done();
+          User.findByUsername(user.usernames[1], function (err, rdoc) {
+            expect(err).to.not.be.ok;
+
+            expect(rdoc).to.be.ok;
+            expect(rdoc).to.be.an('object');
+            expect(rdoc).to.be.an.instanceof(User);
+
+            expect(rdoc.usernames.sort()).to.deep.equal(user.usernames.sort());
+            expect(rdoc.firstName).to.equal(user.firstName);
+            expect(rdoc.lastName).to.equal(user.lastName);
+            expect(rdoc.email).to.equal(user.email);
+
+            done();
+          });
         });
+      });
+    });
+  });
+
+  describe('query index tests with populate', function () {
+    var User, Company;
+    var ts = require('./helpers/pop_setup2');
+    var tsData = ts.getData();
+
+    before(function (done) {
+      if (lounge) {
+        lounge.disconnect();
+      }
+
+      lounge = new lounge.Lounge(); // recreate it
+
+      var cluster = testUtil.getCluser();
+      bucket = cluster.openBucket('lounge_test', function (err) {
+        lounge.connect({
+          bucket: bucket
+        }, function () {
+          bucket.manager().flush(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            var companySchema = lounge.schema({
+              id: {type: String, key: true, generate: true, prefix: 'company::'},
+              name: String,
+              streetAddress: String,
+              city: String,
+              country: String,
+              state: String,
+              postalCode: String
+            });
+
+            Company = lounge.model('Company', companySchema);
+
+            var userSchema = lounge.schema({
+              firstName: String,
+              lastName: String,
+              email: {type: String, index: true},
+              company: Company
+            });
+
+            User = lounge.model('User', userSchema);
+
+            var popData = ts.getData();
+
+            async.each(popData.companies, function (c, eacb) {
+              var company = new Company(c);
+              company.save(eacb);
+            }, function (err) {
+              if (err) {
+                return done(err);
+              }
+
+              async.each(popData.users, function (u, eacb) {
+                var user = new User(u);
+                user.save(eacb);
+              }, done)
+            });
+          });
+        });
+      });
+    });
+
+    it('should query using simple reference document and not populate anything if option not present', function (done) {
+      var email = tsData.users[0].email;
+      User.findByEmail(email, function (err, rdoc) {
+        expect(err).to.not.be.ok;
+
+        expect(rdoc).to.be.ok;
+        expect(rdoc).to.be.an('object');
+        expect(rdoc).to.be.an.instanceof(User);
+        expect(rdoc.id).to.be.ok;
+        expect(rdoc.id).to.be.a('string');
+
+        var userData = tsData.users[0];
+        expect(rdoc.firstName).to.equal(userData.firstName);
+        expect(rdoc.lastName).to.equal(userData.lastName);
+        expect(rdoc.email).to.equal(userData.email);
+        expect(rdoc.company).to.equal(userData.company);
+
+        done();
+      });
+    });
+
+    it('should query using simple reference document and populate as boolean', function (done) {
+      var email = tsData.users[0].email;
+      User.findByEmail(email, {populate: true}, function (err, rdoc) {
+        expect(err).to.not.be.ok;
+
+        expect(rdoc).to.be.ok;
+        expect(rdoc).to.be.an('object');
+        expect(rdoc).to.be.an.instanceof(User);
+        expect(rdoc.id).to.be.ok;
+        expect(rdoc.id).to.be.a('string');
+
+        var userData = tsData.users[0];
+        var companyData = tsData.companies[0];
+
+        expect(rdoc.firstName).to.equal(userData.firstName);
+        expect(rdoc.lastName).to.equal(userData.lastName);
+        expect(rdoc.email).to.equal(userData.email);
+
+        expect(rdoc.company.id).to.equal(companyData.id);
+        expect(rdoc.company.name).to.equal(companyData.name);
+        expect(rdoc.company.streetAddress).to.equal(companyData.streetAddress);
+        expect(rdoc.company.city).to.equal(companyData.city);
+        expect(rdoc.company.country).to.equal(companyData.country);
+        expect(rdoc.company.state).to.equal(companyData.state);
+        expect(rdoc.company.postalCode).to.equal(companyData.postalCode);
+
+        done();
+      });
+    });
+
+    it('should query using simple reference document and populate as string', function (done) {
+      var email = tsData.users[1].email;
+      User.findByEmail(email, {populate: 'company'}, function (err, rdoc) {
+        expect(err).to.not.be.ok;
+
+        expect(rdoc).to.be.ok;
+        expect(rdoc).to.be.an('object');
+        expect(rdoc).to.be.an.instanceof(User);
+        expect(rdoc.id).to.be.ok;
+        expect(rdoc.id).to.be.a('string');
+
+        var userData = tsData.users[1];
+        var companyData = tsData.companies[1];
+
+        expect(rdoc.firstName).to.equal(userData.firstName);
+        expect(rdoc.lastName).to.equal(userData.lastName);
+        expect(rdoc.email).to.equal(userData.email);
+
+        expect(rdoc.company.id).to.equal(companyData.id);
+        expect(rdoc.company.name).to.equal(companyData.name);
+        expect(rdoc.company.streetAddress).to.equal(companyData.streetAddress);
+        expect(rdoc.company.city).to.equal(companyData.city);
+        expect(rdoc.company.country).to.equal(companyData.country);
+        expect(rdoc.company.state).to.equal(companyData.state);
+        expect(rdoc.company.postalCode).to.equal(companyData.postalCode);
+
+        done();
       });
     });
   });


### PR DESCRIPTION
* Added `MemoDriver` class which just wraps our internal `Driver` class and memoizes the `get` function for 5 s
* Optimize internal `findBy*` and internal `populate` functions to use an instance of `MemoDriver` class (new instance for every invocation of public `findBy*`). We clear the cache upon completion. This way we have a cache for duration of processing. When we populate same ids, we only go to db on first one and take advantage of memo cache on subsequents lookups.
* Verified memoization by examining logs.
* Added `options` to `findBy<index>` functions, so we can do populate in them. Added tests.
* Optimize missed array concatenation to use `Array.prototype.push`
* Various minor fixes