### PR TITLE
Add compound index

### DIFF
--- a/lib/cbdocument.utils.js
+++ b/lib/cbdocument.utils.js
@@ -15,9 +15,9 @@ exports.buildIndexObjects = function (initialRefs, currentRefs) {
 
   refValueNames.forEach(refValueName => {
     const initialRefValue = initialRefs[refValueName];
-    const currentlRefValue = currentRefs[refValueName];
+    const currentRefValue = currentRefs[refValueName];
 
-    if (!initialRefValue || !currentlRefValue) {
+    if (!initialRefValue || !currentRefValue) {
       return;
     }
 
@@ -131,40 +131,82 @@ exports.buildRefValues = function (indexes, data) {
       const path = indexes[v].path;
       const name = indexes[v].name;
       const indexType = indexes[v].indexType;
-      const value = mpath.get(path, data);
-      let valToStore = null;
-      if (typeof value === 'string') {
-        valToStore = value;
+
+      const processValue = initialValue => {
+        let finalVal = null;
+        if (typeof initialValue === 'string') {
+          finalVal = initialValue;
+        }
+        if (typeof initialValue === 'number') {
+          finalVal = initialValue.toString();
+        }
+        if (typeof initialValue === 'object' && initialValue._isBaseModel) {
+          finalVal = initialValue.getDocumentKeyValue(initialValue.config.storeFullReferenceId);
+        } else if (Array.isArray(initialValue)) {
+          finalVal = _.map(initialValue, v => {
+            if (v) {
+              if (typeof v === 'string') {
+                return v;
+              }
+              if (typeof v === 'number') {
+                return v.toString();
+              }
+              if (typeof v === 'object' && v._isBaseModel) {
+                return v.getDocumentKeyValue(v.config.storeFullReferenceId);
+              }
+            }
+          });
+
+          finalVal = _.compact(finalVal);
+          finalVal = finalVal.sort();
+        } else if (_.isUndefined(initialValue) || _.isNull(initialValue)) {
+          finalVal = null;
+        }
+        return finalVal;
       }
-      if (typeof value === 'number') {
-        valToStore = value.toString();
-      }
-      if (typeof value === 'object' && value._isBaseModel) {
-        valToStore = value.getDocumentKeyValue(value.config.storeFullReferenceId);
-      } else if (Array.isArray(value)) {
-        valToStore = _.map(value, v => {
-          if (v) {
-            if (typeof v === 'string') {
-              return v;
-            }
-            if (typeof v === 'number') {
-              return v.toString();
-            }
-            if (typeof v === 'object' && v._isBaseModel) {
-              return v.getDocumentKeyValue(v.config.storeFullReferenceId);
-            }
-          }
+
+      let value = null;
+      if (indexes[v].compound) {
+        value = _.map(path, p => {
+          return processValue(mpath.get(p, data));
         });
 
-        valToStore = _.compact(valToStore);
-        valToStore = valToStore.sort();
-      } else if (_.isUndefined(value) || _.isNull(value)) {
-        valToStore = null;
+        const expandValues = valueList => {
+          var retVal = [];
+          _.each(valueList, val => {
+            if (Array.isArray(val)) {
+              let expVal = expandValues(val);
+              let intRet = [];
+              _.each(expVal, v => {
+                intRet.push(retVal.concat(v));
+              });
+              retVal = intRet;
+            } else {
+              retVal.push(val);
+            }
+          });
+          return retVal;
+        }
+
+        value = expandValues(value);
+        value = _.compact(value);
+
+        let containsNested = _.some(value, _.isArray);
+        if (containsNested) {
+          value = _.map(value, v => {
+            return v.join('_');
+          });
+        } else {
+          value = value.join('_');
+        }
+
+      } else {
+        value = processValue(mpath.get(path, data));
       }
 
       ret[name] = {
         path,
-        value: valToStore,
+        value: value,
         name,
         indexType
       };

--- a/lib/model.js
+++ b/lib/model.js
@@ -247,14 +247,46 @@ function setupHooks(InstanceModel) {
 }
 
 function generateIndexFinder(InstanceModel, path, name) {
-  return function indexFind(param, options, fn) {
-    if (!param) {
-      return process.nextTick(fn);
-    }
+  if (Array.isArray(path)){
 
-    const docKey = this.schema.getRefKey(name, param);
-    return InstanceModel._findByIndexValue(docKey, path, options, fn);
-  };
+    return function indexFind(...args) {
+      var fn;
+
+      if (!args || args.length <= path.length) {
+        fn = args.splice(-1);
+        return process.nextTick(fn);
+      }
+
+      var params = args.splice(0, path.length);
+      var options = args.splice(0,1)[0];
+
+      if (args && args.length > 0){
+        fn = args.splice(0,1)[0];
+      } else {
+        fn = options;
+        options = {};
+      }
+
+      if (!fn){
+        fn = _.noop;
+      }
+
+      var param = params.join('_');
+
+      const docKey = this.schema.getRefKey(name, param);
+      return InstanceModel._findByIndexValue(docKey, path, options, fn);
+    };
+
+  } else {
+    return function indexFind(param, options, fn) {
+      if (!param) {
+        return process.nextTick(fn);
+      }
+
+      const docKey = this.schema.getRefKey(name, param);
+      return InstanceModel._findByIndexValue(docKey, path, options, fn);
+    };
+  }
 }
 
 /*!

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import clone from 'clone';
+import inflection from 'inflection';
 
 import * as utils from './utils';
 import * as schemaUtils from './schema.utils';
@@ -187,16 +188,39 @@ export default class Schema {
    *
    */
   index(prop, options = {}){
-    if (!this.descriptor[prop]){
-      throw new Error('Descriptor not found for this field');
+    if (Array.isArray(prop)){
+      _.each(prop, p => {
+        if (!this.descriptor[p]){
+          throw new Error(`Descriptor not found for ${p}`);
+        }
+      });
+
+      let indexType = options.indexType ? options.indexType: 'single';
+      let indexName = options.indexName;
+      if (!indexName){
+        const reg = new RegExp('^\\d+$');
+        indexName = _.map(prop, p => {
+          if (reg.test(p)) {
+            name = p[p.length - 2];
+          }
+          return inflection.singularize(p);
+        });
+        indexName = indexName.join('_and_');
+      }
+
+      this.indexes[indexName] = {path: prop, name: indexName, indexType: indexType, compound: true};
+    } else {
+      if (!this.descriptor[prop]){
+        throw new Error('Descriptor not found for this field');
+      }
+
+      this.descriptor[prop].index = true;
+      this.descriptor[prop] = _.extend(this.descriptor[prop], options);
+
+      let fullDes = {};
+      fullDes[prop] = this.descriptor[prop];
+      this._getIndexes(fullDes);
     }
-
-    this.descriptor[prop].index = true;
-    this.descriptor[prop] = _.extend(this.descriptor[prop], options);
-
-    let fullDes = {};
-    fullDes[prop] = this.descriptor[prop];
-    this._getIndexes(fullDes);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lounge",
   "description": "Simple Mongoose-inspired ODM for Couchbase",
-  "version": "0.5.2",
+  "version": "0.6.0-pre.0",
   "homepage": "https://github.com/bojand/lounge",
   "license": "MIT",
   "repository": {

--- a/test/model.index.spec.js
+++ b/test/model.index.spec.js
@@ -33,7 +33,7 @@ describe('Model index function tests', function () {
     var userSchema = lounge.schema({
       firstName: String,
       lastName: String,
-      email: {type: String, index: true}
+      email: { type: String, index: true }
     });
 
     var User = lounge.model('User', userSchema);
@@ -147,13 +147,69 @@ describe('Model index function tests', function () {
   });
 
 
+  it('should create a compound index', function (done) {
+    var userSchema = lounge.schema({
+      firstName: String,
+      lastName: String,
+      email: String,
+      username: String,
+    });
+
+    userSchema.index(['email', 'username']);
+
+    var User = lounge.model('User', userSchema);
+
+    var user = new User({
+      firstName: 'Joe',
+      lastName: 'Smith',
+      email: 'joe3@gmail.com',
+      username: 'jsmith'
+    });
+
+    var indexCalled = false;
+    user.on('index', function (err) {
+      indexCalled = true;
+    });
+
+    function checkIndexRes(err, indexRes) {
+      expect(err).to.not.be.ok;
+      expect(indexRes).to.be.ok;
+      expect(indexRes.value).to.be.ok;
+      expect(indexRes.value.key).to.be.ok;
+      expect(indexRes.value.key).to.equal(user.getDocumentKeyValue(true));
+    }
+
+    function checkGetRes(err, gd) {
+      expect(err).to.not.be.ok;
+      expect(gd).to.be.ok;
+      expect(gd.value).to.be.ok;
+      expect(gd.value.email).to.equal(user.email);
+      expect(gd.value.firstName).to.equal(user.firstName);
+      expect(gd.value.lastName).to.equal(user.lastName);
+    }
+
+    user.save(function (err, savedDoc) {
+      expect(err).to.not.be.ok;
+      expect(savedDoc).to.be.ok;
+
+      var k = userSchema.getRefKey('email_and_username', user.email + '_' + user.username);
+      bucket.get(k, function (err, indexRes) {
+        checkIndexRes(err, indexRes);
+
+        bucket.get(indexRes.value.key, function (err, gd) {
+          checkGetRes(err, gd);
+          done();
+        });
+      });
+    });
+  });
 
   it('should index() using simple reference document using key options', function (done) {
     var userSchema = lounge.schema({
       firstName: String,
       lastName: String,
-      email: {type: String, index: true},
-      username: {type: String, key: true, generate: false}
+      email: { type: String, index: true },
+      username: { type: String, key: true, generate: false }
     });
 
     var User = lounge.model('User', userSchema);
@@ -230,8 +286,8 @@ describe('Model index function tests', function () {
     var userSchema = lounge.schema({
       firstName: String,
       lastName: String,
-      email: {type: String, index: true},
-      username: {type: String, index: true, indexName: 'userName'}
+      email: { type: String, index: true },
+      username: { type: String, index: true, indexName: 'userName' }
     });
 
     var User = lounge.model('User', userSchema);
@@ -315,7 +371,7 @@ describe('Model index function tests', function () {
     });
 
     userSchema.index('email');
-    userSchema.index('username', {indexName: 'userName'});
+    userSchema.index('username', { indexName: 'userName' });
 
     var User = lounge.model('User', userSchema);
 
@@ -393,8 +449,8 @@ describe('Model index function tests', function () {
     var userSchema = lounge.schema({
       firstName: String,
       lastName: String,
-      email: {type: String, key: true, generate: false},
-      usernames: [{type: String, index: true, indexName: 'username'}]
+      email: { type: String, key: true, generate: false },
+      usernames: [{ type: String, index: true, indexName: 'username' }]
     }, {
       refIndexKeyPrefix: 'app::dev::ref::',
       delimiter: '::'
@@ -477,10 +533,100 @@ describe('Model index function tests', function () {
     });
   });
 
+  it('should index() using array of reference documents with a compound index', function (done) {
+    var userSchema = lounge.schema({
+      firstName: String,
+      lastName: String,
+      email: { type: String, key: true, generate: false },
+      usernames: [{ type: String, indexName: 'username' }]
+    }, {
+      refIndexKeyPrefix: 'app::dev::ref::',
+      delimiter: '::'
+    });
+
+    userSchema.index(['email', 'usernames']);
+
+    var User = lounge.model('User', userSchema);
+
+    var user = new User({
+      firstName: 'Joe',
+      lastName: 'Smith',
+      email: 'joe@gmail.com',
+      usernames: ['js1', 'js2', 'js3']
+    });
+
+    user.save(function (err, savedDoc) {
+      expect(err).to.not.be.ok;
+      expect(savedDoc).to.be.ok;
+
+      var indexCalled = 0;
+      user.on('index', function (err) {
+        indexCalled = indexCalled + 1;
+      });
+
+      var keys = _.map(user.usernames, function (un) {
+        return userSchema.getRefKey('email_and_username', user.email + '_' + un);
+      });
+
+      bucket.getMulti(keys, function (err, indexRes) {
+        expect(err).to.not.be.ok;
+        expect(indexRes).to.be.ok;
+
+        var resKeys = Object.keys(indexRes);
+
+        _.each(resKeys, function (ik) {
+          var v = indexRes[ik].value;
+          expect(v).to.be.ok;
+          expect(v.key).to.be.ok;
+          expect(v.key).to.equal(user.email);
+        });
+
+        user.usernames = ['jsnew1', 'js2', 'jsnew3'];
+
+        user.index(function (err) {
+          expect(err).to.not.be.ok;
+
+          // check old ones
+          keys = _.map(['js1', 'js3'], function (un) {
+            return userSchema.getRefKey('email_and_username', user.email + '_' + un);
+          });
+
+          bucket.getMulti(keys, function (err, indexRes) {
+
+            expect(err).to.be.ok;
+            expect(err).to.equal(2);
+
+            keys = _.map(user.usernames, function (un) {
+              return userSchema.getRefKey('email_and_username', user.email + '_' + un);
+            });
+
+            bucket.getMulti(keys, function (err, indexRes) {
+              expect(err).to.not.be.ok;
+              expect(indexRes).to.be.ok;
+
+              var resKeys = Object.keys(indexRes);
+
+              _.each(resKeys, function (ik) {
+                var v = indexRes[ik].value;
+                expect(v).to.be.ok;
+                expect(v.key).to.be.ok;
+                expect(v.key).to.equal(user.email);
+              });
+
+              expect(indexCalled).to.equal(1);
+
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
   it('should index using simple reference document for array index type', function (done) {
     var userSchema = lounge.schema({
       name: String,
-      email: {type: String, index: true, indexType: 'array'}
+      email: { type: String, index: true, indexType: 'array' }
     });
 
     var User = lounge.model('User', userSchema);
@@ -544,13 +690,85 @@ describe('Model index function tests', function () {
     });
   });
 
+  it('should index using simple reference document for array index type with compound index', function (done) {
+    var userSchema = lounge.schema({
+      name: String,
+      email: String,
+      username: String
+    });
+
+    userSchema.index(['email', 'username'], { indexType: 'array' });
+
+    var User = lounge.model('User', userSchema);
+
+    var user = new User({
+      name: 'Joe Smith',
+      email: 'joe@gmail.com',
+      username: 'jsmith'
+    });
+
+    var user2 = new User({
+      name: 'Bob Jones',
+      email: 'joe@gmail.com',
+      username: 'jsmith'
+    });
+
+    var indexCalled = false;
+    user.on('index', function () {
+      indexCalled = true;
+    });
+
+    function checkRes(indexRes, expected) {
+
+      expect(indexRes).to.be.ok;
+      expect(indexRes.value).to.be.ok;
+      expect(indexRes.value.keys).to.be.ok;
+      expect(indexRes.value.keys).to.deep.equal(expected);
+    }
+
+    user.index(function (err, indexDoc) {
+      expect(err).to.not.be.ok;
+
+      user2.index(function (err, savedDoc) {
+
+        var k = userSchema.getRefKey('email_and_username', user.email + '_' + user.username);
+        bucket.get(k, function (err, indexRes) {
+          expect(err).to.not.be.ok;
+          checkRes(indexRes, [user.id, user2.id]);
+
+          user.email = 'joe2@gmail.com';
+
+          user.index(function (err, indexRes) {
+            expect(err).to.not.be.ok;
+
+            // old one
+            k = userSchema.getRefKey('email_and_username', 'joe@gmail.com' + '_' + user.username);
+            bucket.get(k, function (err, indexRes) {
+              expect(err).to.not.be.ok;
+              checkRes(indexRes, [user2.id]);
+
+              k = userSchema.getRefKey('email_and_username', user.email + '_' + user.username);
+              bucket.get(k, function (err, indexRes) {
+                checkRes(indexRes, [user.id]);
+
+                expect(indexCalled).to.be.ok;
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   it('should index using simple reference document for array index type defined separately', function (done) {
     var userSchema = lounge.schema({
       name: String,
       email: String
     });
 
-    userSchema.index('email', {indexType: 'array'});
+    userSchema.index('email', { indexType: 'array' });
 
     var User = lounge.model('User', userSchema);
 
@@ -616,7 +834,7 @@ describe('Model index function tests', function () {
   it('should index using array reference document for array index type', function (done) {
     var userSchema = lounge.schema({
       name: String,
-      email: [{type: String, index: true, indexType: 'array'}]
+      email: [{ type: String, index: true, indexType: 'array' }]
     });
 
     var User = lounge.model('User', userSchema);
@@ -656,7 +874,11 @@ describe('Model index function tests', function () {
         bucket.getMulti(keys, function (err, indexRes) {
           expect(err).to.not.be.ok;
 
-          var ex = [[user.id], [user.id, user2.id], [user2.id]];
+          var ex = [
+            [user.id],
+            [user.id, user2.id],
+            [user2.id]
+          ];
           _.values(indexRes).forEach(function (ir, i) {
             checkRes(ir, ex[i]);
           });
@@ -679,7 +901,11 @@ describe('Model index function tests', function () {
               bucket.getMulti(keys, function (err, indexRes) {
                 expect(err).to.not.be.ok;
 
-                var ex = [[user.id, user2.id], [user2.id], [user.id]];
+                var ex = [
+                  [user.id, user2.id],
+                  [user2.id],
+                  [user.id]
+                ];
                 _.values(indexRes).forEach(function (ir, i) {
                   checkRes(ir, ex[i]);
                 });
@@ -705,8 +931,8 @@ describe('Model index function tests', function () {
 
     var userSchema = lounge.schema({
       name: String,
-      email: {type: String, key: true, generate: 'false'},
-      company: {type: Company, index: true}
+      email: { type: String, key: true, generate: 'false' },
+      company: { type: Company, index: true }
     });
 
     var User = lounge.model('User', userSchema);
@@ -779,8 +1005,8 @@ describe('Model index function tests', function () {
 
     var userSchema = lounge.schema({
       name: String,
-      email: {type: String, key: true, generate: 'false'},
-      company: [{type: Company, index: true}]
+      email: { type: String, key: true, generate: 'false' },
+      company: [{ type: Company, index: true }]
     });
 
     var User = lounge.model('User', userSchema);
@@ -869,8 +1095,8 @@ describe('Model index function tests', function () {
 
     var userSchema = lounge.schema({
       name: String,
-      email: {type: String, key: true, generate: false},
-      company: {type: Company, index: true, indexType: 'array'}
+      email: { type: String, key: true, generate: false },
+      company: { type: Company, index: true, indexType: 'array' }
     });
 
     var User = lounge.model('User', userSchema);
@@ -952,7 +1178,7 @@ describe('Model index function tests', function () {
 
     var userSchema = lounge.schema({
       name: String,
-      company: [{type: Company, index: true, indexType: 'array'}]
+      company: [{ type: Company, index: true, indexType: 'array' }]
     });
 
     var User = lounge.model('User', userSchema);
@@ -1007,7 +1233,11 @@ describe('Model index function tests', function () {
         bucket.getMulti(keys, function (err, indexRes) {
           expect(err).to.not.be.ok;
 
-          var ex = [[user.id], [user.id, user2.id], [user2.id]];
+          var ex = [
+            [user.id],
+            [user.id, user2.id],
+            [user2.id]
+          ];
           _.values(indexRes).forEach(function (ir, i) {
             checkRes(ir, ex[i]);
           });
@@ -1030,7 +1260,11 @@ describe('Model index function tests', function () {
               bucket.getMulti(keys, function (err, indexRes) {
                 expect(err).to.not.be.ok;
 
-                var ex = [[user.id, user2.id], [user2.id], [user.id]];
+                var ex = [
+                  [user.id, user2.id],
+                  [user2.id],
+                  [user.id]
+                ];
                 _.values(indexRes).forEach(function (ir, i) {
                   checkRes(ir, ex[i]);
                 });


### PR DESCRIPTION
Using the schema.index() function we can now pass an array to create a compound index. This will result in properties being index by all fields passed.

eg - 

schema.index(['email', 'username']); 

will index the document as $ref_by_email_and_username_{$email}_{$username}