### PR TITLE
Check to ensure that data passed to create index ref values is an object

### DIFF
--- a/lib/cbdocument.js
+++ b/lib/cbdocument.js
@@ -41,7 +41,10 @@ class CouchbaseDocument extends Document {
       key: null
     }
 
-    _.merge(this[_privateKey]._o.refValues, cdocUtils.buildRefValues(this.schema.indexes, values))
+    if (_.isObject(values)) {
+      _.merge(this[_privateKey]._o.refValues, cdocUtils.buildRefValues(this.schema.indexes, values))
+    }
+
     this[_privateKey]._o.key = this.getDocumentKeyValue()
   }
 

--- a/test/model.basics.spec.js
+++ b/test/model.basics.spec.js
@@ -646,6 +646,28 @@ describe('Model basics', function () {
 
       expect(user._isNew).to.be.undefined
     })
+
+    it('should properly create an empty model when it has an indexed field', function () {
+      var userSchema = lounge.schema({
+        firstName: String,
+        lastName: String,
+        email: { type: String, index: true, indexType: 'array' }
+      })
+
+      var User = lounge.model('User', userSchema)
+
+      var user = new User()
+
+      expect(user instanceof User).to.be.ok
+      expect(user instanceof lounge.Document).to.be.ok
+      expect(user instanceof lounge.Model).to.be.ok
+
+      expect(user.id).to.be.a('string')
+      expect(user.id).to.be.ok
+      expect(user.firstName).to.not.be.ok
+      expect(user.lastName).to.not.be.ok
+      expect(user.email).to.not.be.ok
+    })
   })
 
   describe('Nested properties tests', function () {

--- a/test/model.save.spec.js
+++ b/test/model.save.spec.js
@@ -1396,6 +1396,40 @@ describe('Model save tests', function () {
     })
   })
 
+  it('should properly save an empty model when it has an indexed field', function (done) {
+    var userSchema = lounge.schema({
+      firstName: String,
+      lastName: String,
+      email: { type: String, index: true }
+    })
+
+    var User = lounge.model('User', userSchema)
+
+    var user = new User()
+
+    user.save(function (err, savedDoc) {
+      expect(err).to.not.be.ok
+      expect(savedDoc).to.be.ok
+      expect(savedDoc).to.be.an('object')
+      expect(savedDoc.id).to.be.ok
+      expect(savedDoc.id).to.be.a('string')
+
+      bucket.get(savedDoc.getDocumentKeyValue(true), function (err, dbDoc) {
+        expect(err).to.not.be.ok
+        expect(dbDoc).to.be.ok
+        expect(dbDoc.value).to.be.ok
+        expect(dbDoc.value).to.be.an('object')
+
+        var expected = {
+          id: savedDoc.getDocumentKeyValue(true)
+        }
+
+        expect(dbDoc.value).to.deep.equal(expected)
+        done()
+      });
+    })
+  })
+
   describe('save() pre hooks tests', function () {
     this.slow(200)
 


### PR DESCRIPTION
This PR fixes issues when created a lounge model without passing any argument data to the constructor.

I wasn't sure if the package-lock should be updated to the current version, so if not I can just remove it from the PR.