### PR TITLE
Apply refKeyCase in buildRefValues

### DIFF
--- a/lib/cbdocument.utils.js
+++ b/lib/cbdocument.utils.js
@@ -125,6 +125,12 @@ function buildRefValues (indexes, data) {
         value = processValue(mpath.get(path, data))
       }
 
+      if (indexes[v].refKeyCase === 'upper') {
+        value = value.toUpperCase()
+      } else if (indexes[v].refKeyCase === 'lower') {
+        value = value.toLowerCase()
+      }
+
       ret[name] = {
         path,
         value,

--- a/test/model.index.save.spec.js
+++ b/test/model.index.save.spec.js
@@ -1083,4 +1083,39 @@ describe('Model index on save tests', function () {
       })
     })
   })
+
+  it('should index sucessfully with matching ref but different case, when refKeyCase is set', function (done) {
+    var userSchema = lounge.schema({
+      email: { type: String, index: true, indexType: 'array', refKeyCase: 'lower' }
+    })
+
+    userSchema.pre('save', function (next) {
+      if (this.email) {
+        this.email = this.email.toLowerCase()
+      }
+
+      next()
+    })
+
+    var User = lounge.model('User', userSchema)
+
+    var user = new User({
+      email: 'joe@gmail.com'
+    })
+
+    user.save({ waitForIndex: true }, function (err, savedDoc) {
+      expect(err).to.not.be.ok
+      expect(savedDoc).to.be.ok
+
+      var user2 = new User({
+        email: 'JOE@gmail.com'
+      })
+      user2.save({ waitForIndex: true }, function (err, savedDoc) {
+        expect(err).to.not.be.ok
+        expect(savedDoc).to.be.ok
+
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Relates to #86 

Apply refKeyCase in buildRefValues so that correct upsert/remove is chosen during buildIndexObjects.

Found this edge case scenario in the app-code and isolated it to 100% reproducibility (See added test case). If the index has a refKeyCase _and_ preSave modification to that field, adding a doc with a value for that field with a case different than what was previous saved, will cause lounge to setup a `remove` and an `upsert` back to back for what ends up being the same ref document, and this results in a couchbase "Temporary failure" 100% of the time on save/index, presumably because its trying to remove and mutate the same doc, essentially at the same time? In any case, it shouldn't even be trying to remove in the first place in this scenario, and the fix in this PR causes the ref compare to properly identify that it is just an upsert.

To see the failure, the added test needs to be run without the CB mock:

`DEBUG=lounge node_modules/.bin/mocha --exit test/model.index.save.spec.js`

```
lounge array index. operation: upsert key: $_ref_by_email_joe@gmail.com refKeyValue: 9d69764c-a4e5-44eb-9563-7fc1ebc845b1 +335ms
lounge array index: mutateIn $_ref_by_email_joe@gmail.com +1ms
lounge array index: $_ref_by_email_joe@gmail.com not found for mutateIn trying to do atomic transform +0ms
lounge save. type: User  key: 9d69764c-a4e5-44eb-9563-7fc1ebc845b1 +1ms
lounge array index. operation: remove key: $_ref_by_email_joe@gmail.com refKeyValue: 08add56d-a643-46db-98d8-324136e72e7b +1ms
lounge array index. operation: upsert key: $_ref_by_email_joe@gmail.com refKeyValue: 08add56d-a643-46db-98d8-324136e72e7b +0ms
lounge array index: mutateIn $_ref_by_email_joe@gmail.com +0ms
lounge Temporary failure received from server. Try again later +1ms
1) should index sucessfully with matching ref but different case, when refKeyCase is set


  17 passing (6s)
  1 failing

  1) Model index on save tests
       should index sucessfully with matching ref but different case, when refKeyCase is set:
     Uncaught CouchbaseError: Temporary failure received from server. Try again later
```

Note the remove/upsert of the same document key.

Running that test, with the fix, it adds the new document, with the correct refkey, every time. 