### PR TITLE
fix "this" when using default function in descriptor

### DIFF
--- a/lib/basemodel.js
+++ b/lib/basemodel.js
@@ -175,6 +175,15 @@ function build (extendEventEmitter) {
           properties.readOnly = readOnly
         }
       })
+      
+      // Populate runtime values as provided to this instance of object.
+      if (_.isObject(values)) {
+        let data = values
+        if (options.clone) {
+          data = clone(values)
+        }
+        this.set(data)
+      }
 
       // May return actual object instance or Proxy, depending on harmony support.
       return _private._this

--- a/lib/basemodel.js
+++ b/lib/basemodel.js
@@ -156,6 +156,15 @@ function build (extendEventEmitter) {
         })
       }
 
+      // Populate runtime values as provided to this instance of object.
+      if (_.isObject(values)) {
+        let data = values
+        if (options.clone) {
+          data = clone(values)
+        }
+        this.set(data)
+      }
+
       // Populate schema defaults into object.
       _.each(schema.descriptor, (properties, index) => {
         if (properties.default !== undefined) {
@@ -166,15 +175,6 @@ function build (extendEventEmitter) {
           properties.readOnly = readOnly
         }
       })
-
-      // Populate runtime values as provided to this instance of object.
-      if (_.isObject(values)) {
-        let data = values
-        if (options.clone) {
-          data = clone(values)
-        }
-        this.set(data)
-      }
 
       // May return actual object instance or Proxy, depending on harmony support.
       return _private._this

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -146,22 +146,6 @@ describe('Type tests', function () {
         expect(user.initials).equal('BW')
         done()
       })
-
-      // it('it should fail because this is empty', function (done) {
-      //   var userSchema = lounge.schema({
-      //     fullName: String,
-      //     initials: {
-      //       type: String,
-      //       default: function () {
-      //         var initials = this.fullName.match(/\b\w/g) || []
-      //         return ((initials.shift() || '') + (initials.pop() || '')).toUpperCase()
-      //       }
-      //     }
-      //   })
-      //   var User = lounge.model('User', userSchema)
-      //   expect(() => new User({fullName: 'Bruce Wayne'})).to.throw(TypeError)
-      //   done()
-      // })
     })
 
     describe('alias', function () {

--- a/test/types.spec.js
+++ b/test/types.spec.js
@@ -130,6 +130,38 @@ describe('Type tests', function () {
         expect(_.isEqual(obj, stillSameObject)).to.be.true
         done()
       })
+      it('it should be ok to use this in default', function (done) {
+        var userSchema = lounge.schema({
+          fullName: String,
+          initials: {
+            type: String,
+            default: function () {
+              var initials = this.fullName.match(/\b\w/g) || []
+              return ((initials.shift() || '') + (initials.pop() || '')).toUpperCase()
+            }
+          }
+        })
+        var User = lounge.model('User', userSchema)
+        var user = new User({fullName: 'Bruce Wayne'})
+        expect(user.initials).equal('BW')
+        done()
+      })
+
+      // it('it should fail because this is empty', function (done) {
+      //   var userSchema = lounge.schema({
+      //     fullName: String,
+      //     initials: {
+      //       type: String,
+      //       default: function () {
+      //         var initials = this.fullName.match(/\b\w/g) || []
+      //         return ((initials.shift() || '') + (initials.pop() || '')).toUpperCase()
+      //       }
+      //     }
+      //   })
+      //   var User = lounge.model('User', userSchema)
+      //   expect(() => new User({fullName: 'Bruce Wayne'})).to.throw(TypeError)
+      //   done()
+      // })
     })
 
     describe('alias', function () {


### PR DESCRIPTION
When using default function, "this" keyword return an empty object. setting the values in runtime defore populating the schema defaults into object would fix the problem. 